### PR TITLE
Fix/registration accoount activation

### DIFF
--- a/Backend/src/main/java/com/example/OnlyBuns/config/WebSecurityConfig.java
+++ b/Backend/src/main/java/com/example/OnlyBuns/config/WebSecurityConfig.java
@@ -109,6 +109,7 @@ public class WebSecurityConfig {
 								.requestMatchers(HttpMethod.DELETE, "/api/posts/{postId}").permitAll()
 								.requestMatchers(HttpMethod.PUT, "/api/posts/{postId}").permitAll()
 						.requestMatchers("/signin", "/signup", "/auth/**").permitAll()
+						.requestMatchers("/auth/activate/**").permitAll()
 						.requestMatchers("/auth/login").permitAll()
 						.requestMatchers("/api/foo").permitAll() // Dozvoljavaš ove rute bez autentifikacije
 						.requestMatchers("/api/clients").permitAll()

--- a/Backend/src/main/java/com/example/OnlyBuns/service/ClientService.java
+++ b/Backend/src/main/java/com/example/OnlyBuns/service/ClientService.java
@@ -123,7 +123,8 @@ public class ClientService {
     public boolean activateUser(String email) {
         Client client = clientRepository.findByEmail(email);
         if (client != null) {
-            client.setActive(true); // Postavlja korisnika kao aktivnog
+            client.setActive(true);
+            client.setEnabled(true);// Postavlja korisnika kao aktivnog
             clientRepository.save(client);
             return true;// Spasavanje u bazi
         }

--- a/Frontend/frontend/src/app/activate-account/activate-account.component.ts
+++ b/Frontend/frontend/src/app/activate-account/activate-account.component.ts
@@ -20,10 +20,12 @@ export class ActivateAccountComponent implements OnInit {
   ngOnInit(): void {
     const token = this.route.snapshot.paramMap.get('token');
     console.log('usao ovdjeeeeeeeeeee');
+    console.log('token', token);
     // Dohvati token iz URL-a
 
     if (token) {
-      console.log(token)
+      console.log(token);
+      console.log('Calling backend to activate account...');
       this.authService.activateAccount(token).subscribe(
         response => {
           this.message = 'Your account has been successfully activated!';

--- a/Frontend/frontend/src/app/service/auth.service.ts
+++ b/Frontend/frontend/src/app/service/auth.service.ts
@@ -24,13 +24,16 @@ export class AuthService {
 
   initializeAuthState() {
     const token = this.getToken();
-    if (token) {
-      // Optionally validate the token with the server
-      this.access_token = token;
-      this.initializeSession();
-    } else {
-      this.logout();
-    }
+     if (window.location.href.includes('/activate/')) {
+    return;
+  }
+
+  if (token) {
+    this.access_token = token;
+    this.initializeSession();
+  } else {
+    this.logout();
+  }
   }
 
   initializeSession() {
@@ -91,13 +94,14 @@ export class AuthService {
   }
 
   activateAccount(token: string): Observable<any> {
+    console.log("usaosaoaoo activation radi nestoo");
     const headers = new HttpHeaders({
       'Authorization': `Bearer ${this.getToken()}`,
       'Accept': 'application/json',
       'Content-Type': 'application/json'
     });
   
-    return this.apiService.get(this.config.activation_url + `/${token}`, { headers });
+    return this.apiService.get(`${this.config.activation_url}/${token}`, { headers });
   }
 
   tokenIsPresent() {


### PR DESCRIPTION
This PR fixes the issue where newly registered users were unable to activate and log into their accounts.

What was fixed:
• Account activation now works correctly when a user clicks the activation link sent via email.
• After activation, the user is redirected to the login page and is now able to log in successfully.