### PR TITLE
Feat: Implement scheduled cleanup of inactive accounts

### DIFF
--- a/Backend/src/main/java/com/example/OnlyBuns/OnlyBunsApplication.java
+++ b/Backend/src/main/java/com/example/OnlyBuns/OnlyBunsApplication.java
@@ -5,9 +5,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableCaching
+@EnableScheduling
 public class OnlyBunsApplication {
 
 	public static void main(String[] args) {

--- a/Backend/src/main/java/com/example/OnlyBuns/repository/ClientRepository.java
+++ b/Backend/src/main/java/com/example/OnlyBuns/repository/ClientRepository.java
@@ -4,8 +4,11 @@ import com.example.OnlyBuns.model.Client;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -30,4 +33,7 @@ public interface ClientRepository extends JpaRepository<Client, Integer> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select c from Client c where c.id = :id")
     Optional<Client> findByIdForUpdate(@Param("id") Integer id);
+
+    @Query("SELECT c FROM Client c WHERE c.enabled = false")
+    List<Client> findUnactivatedClients();
 }

--- a/Backend/src/main/java/com/example/OnlyBuns/service/AccountCleanupService.java
+++ b/Backend/src/main/java/com/example/OnlyBuns/service/AccountCleanupService.java
@@ -1,0 +1,40 @@
+package com.example.OnlyBuns.service;
+
+import com.example.OnlyBuns.model.Client;
+import com.example.OnlyBuns.repository.ClientRepository;
+import jakarta.transaction.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class AccountCleanupService {
+    private static final Logger log = LoggerFactory.getLogger(AccountCleanupService.class);
+    private final ClientRepository clientRepository;
+
+    @Autowired
+    public AccountCleanupService(ClientRepository clientRepository) {
+        this.clientRepository = clientRepository;
+    }
+
+    /**
+     * Zakazani zadatak koji se izvršava u 02:00 ujutru posljednjeg dana svakog mjeseca.
+     * Zadatak briše neaktivirane naloge.
+     */
+    @Scheduled(cron = "0 0 2 L * ?")
+    @Transactional
+    public void purgeUnactivatedAccounts() {
+        log.info("--- Pokretanje zakazanog zadatka: Brisanje neaktiviranih naloga ---");
+        List<Client> clientsToDelete = clientRepository.findUnactivatedClients();
+
+        if (!clientsToDelete.isEmpty()) {
+            clientRepository.deleteAll(clientsToDelete);
+            System.out.println("Obrisano " + clientsToDelete.size() + " neaktiviranih klijenata.");
+        }
+    }
+}

--- a/Frontend/frontend/src/app/home/post/post.component.ts
+++ b/Frontend/frontend/src/app/home/post/post.component.ts
@@ -82,6 +82,7 @@ export class PostComponent {
   }
 
   submitNewPost() {
+    console.log(this.newPost.imagePath)
     this.postService.createPost(this.newPost).subscribe(
       response => {
         console.log('Post created successfully:', response);


### PR DESCRIPTION
This PR introduces a scheduled task to delete inactive user accounts on the last day of each month. Inactive accounts are defined as those that have been created but not activated via email.

